### PR TITLE
Modified SftpClient.prototype.get function to return the read stream

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -214,11 +214,8 @@ SftpClient.prototype.get = function(path, dst, options) {
         });
 
         if (dst === undefined) {
-          // no dst specified, return buffer of data
-          let concatStream = concat(buff => {
-            return resolve(buff);
-          });
-          rdr.pipe(concatStream);
+          // no dst specified, return read stream
+          return resolve(rdr);
         } else if (typeof dst === 'string') {
           // dst local file path
           let wtr = fs.createWriteStream(dst);


### PR DESCRIPTION
Return read stream rather than a buffer when dst parameter is not defined. 